### PR TITLE
Removed a redundant file

### DIFF
--- a/simple_frontend/package-lock.json
+++ b/simple_frontend/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "simple_frontend",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
The package-lock.json on the simple_frontend directory was redundant and project can run fine without it. 
-"npm install " must have been ran on the directory hence the file.